### PR TITLE
Add XML Serialization  

### DIFF
--- a/ctr/util/serialize.py
+++ b/ctr/util/serialize.py
@@ -107,11 +107,11 @@ class XmlSerialize:
         # Create an empty xml document with custom root name
         self.document: Element = Element(self.rootName, attributes)
 
-    def add(self, tag: str, elemText: str = None, **attributes) -> None:
+    def add(self, tag: str, elementText: str = None, **attributes) -> None:
         """Adds an element to the XML document"""
         element = SubElement(self.document, tag,
                              attributes)
-        element.text = elemText
+        element.text = elementText
 
     def insert_from_attr(self, attributeDict: dict, tag, elementText: str = None, **attributes):
         """Inserts a sub-element into an element given its attributes match"""

--- a/ctr/util/serialize.py
+++ b/ctr/util/serialize.py
@@ -1,16 +1,17 @@
-import json
+from xml.etree.ElementTree import Element, SubElement, tostring, indent
+
 
 class JsonSerialize:
-    
+
     string: str = ""
 
     def __init__(self, data: str = ""):
         self.string = data.strip()
-    
+
     def add(self, key, var, wrapVarInQuotes=False):
         if self.string == "":
             self.string = "{"
-        
+
         match self.string[-1]:
             case "}":
                 self.string = self.string[:-1] + ","
@@ -27,7 +28,7 @@ class JsonSerialize:
             self.string += f"\"{key}\": \"{var_to_json(var)}\""
         else:
             self.string += f"\"{key}\": {var_to_json(var)}"
-        
+
         self.string += "}"
 
     def serialize(self):
@@ -35,10 +36,12 @@ class JsonSerialize:
             self.string += "}"
         return self.string
 
+
 def format_line(key, var, wrapVarInQuotes=False):
     if wrapVarInQuotes:
         return f"\"{key}\": \"{var_to_json(var)}\""
     return f"\"{key}\": {var_to_json(var)}"
+
 
 def var_to_json(var):
     if type(var) is dict:
@@ -60,11 +63,13 @@ def var_to_json(var):
     else:
         return str(var)
 
+
 def dict_to_json(var):
     if len(var) == 0:
         return "{}"
     else:
         return "{" + ", ".join(f'"{key}": {var_to_json(value)}' for key, value in var.items()) + "}"
+
 
 def list_to_json(var):
     if len(var) == 0:
@@ -72,19 +77,67 @@ def list_to_json(var):
     else:
         return "[" + ", ".join(var_to_json(value) for value in var) + "]"
 
+
 def str_to_json(var):
     return '"{}"'.format(var)
+
 
 def int_to_json(var):
     return str(var)
 
+
 def float_to_json(var):
     return str(var)
+
 
 def bool_to_json(var):
     if var:
         return "true"
     return "false"
 
+
 def null_to_json(_):
     return "null"
+
+
+class XmlSerialize:
+    def __init__(self, rootName: str, **attributes):
+        """A class utilized for writing to a XML document"""
+        self.rootName: str = rootName
+        # Create an empty xml document with custom root name
+        self.document: Element = Element(self.rootName, attributes)
+
+    def add(self, tag: str, elemText: str = None, **attributes) -> None:
+        """Adds an element to the XML document"""
+        element = SubElement(self.document, tag,
+                             attributes)
+        element.text = elemText
+
+    def insert_from_attr(self, attributeDict: dict, tag, elementText: str = None, **attributes):
+        """Inserts a sub-element into an element given its attributes match"""
+        # TODO: Implement partial attribute matching
+        allElements = [elem for elem in self.document.iter()]
+        for element in allElements:
+            # Match the attributes to the given dict
+            if element.attrib == attributeDict:
+                newSubElement = SubElement(element, tag, **attributes)
+                newSubElement.text = elementText
+
+    def insert_from_tag(self, tag, newTag, elementText: str = None, **attributes):
+        """Inserts a sub-element into an element given its tag match"""
+        allElements = [elem for elem in self.document.iter()]
+        for elem in allElements:
+            # Match the attributes to the tag name
+            if elem.tag == tag:
+                newSubElement = SubElement(elem, newTag, **attributes)
+                newSubElement.text = elementText
+
+    def serialize(self, encoding: str) -> str:
+        """Serializes the XML Document into a string object"""
+        # Prettify the document
+        indent(self.document, level=0)
+
+        # Remove dash from encoding for adding to xml header
+        headerEncoding: str = encoding.replace("-", "").lower()
+
+        return tostring(self.document, encoding=headerEncoding, method='xml').decode(headerEncoding)


### PR DESCRIPTION
This PR adds a new class to `serialize.py` called `XmlSerialize`. This class is implements functions that use the `ElementTree` module. It adds most of the needed components to create xml documents and serialize objects into xml.  At the moment, it only supports `str` objects as `ElementTree` only supports `str` objects too. This shouldn't create many issues, as I already have built a working `to_xml` method in MSBP that will be in a seperate PR, but I do plan on doing other objects too, let me know if you need that before merging. Here are some examples:

Creation of an xml document
```py
document = XmlSerialize("root", attribute="1")
```
```xml
<root level="0">
</root>
```
Adding an element 
```py
document.add("element", "Isn't this pretty cool?")
```
```xml
<root level="0">
</root>
<element>Isn't this pretty cool?</element>
```
Inserting an element given tag name

```py
document.insert_from_tag("root", "insideRoot", level="1")
```
```xml
<root level="0">
<insideRoot lavel="1"></insideRoot>
</root>
<element>Isn't this pretty cool?</element>
```
Inserting an element given attributes

```py
document.insert_from_attr({"level": "1"},  "insideInsideroot",  level="2"))
```

```xml
<root level="0">
  <insideRoot level="1">
     <insideInsideRoot level="2"></insideInsideRoot>
  </insideRoot>
</root>
<element>Isn't this pretty cool?</element>
```




